### PR TITLE
fix: table db name

### DIFF
--- a/src/main/java/com/example/onlinecourses/model/ScheduleDB.java
+++ b/src/main/java/com/example/onlinecourses/model/ScheduleDB.java
@@ -1,11 +1,9 @@
 package com.example.onlinecourses.model;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.*;
 
+@Table(name = "schedule")
 @Entity
 @Data
 @NoArgsConstructor

--- a/src/main/java/com/example/onlinecourses/model/TeacherDB.java
+++ b/src/main/java/com/example/onlinecourses/model/TeacherDB.java
@@ -1,11 +1,9 @@
 package com.example.onlinecourses.model;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.*;
 
+@Table(name = "teacher")
 @Entity
 @Data
 @NoArgsConstructor


### PR DESCRIPTION
This pull request includes changes to the `ScheduleDB` and `TeacherDB` classes in the `com.example.onlinecourses.model` package to improve database table mapping by adding `@Table` annotations.

Changes to database table mapping:

* [`src/main/java/com/example/onlinecourses/model/ScheduleDB.java`](diffhunk://#diff-cbd48608192d6476cd060c634cf1bda2ae55bb62b4bcf669a012b584fc4e521cL3-R6): Added `@Table(name = "schedule")` annotation to map the `ScheduleDB` class to the "schedule" table in the database.
* [`src/main/java/com/example/onlinecourses/model/TeacherDB.java`](diffhunk://#diff-df10ec859234457702a9720da0aef264e9b9064c6e9d2e6c21ffa6e6f45797f0L3-R6): Added `@Table(name = "teacher")` annotation to map the `TeacherDB` class to the "teacher" table in the database.